### PR TITLE
set expanded() onto _FlashTabBarItem and expose shadow params

### DIFF
--- a/lib/flashy_tab_bar.dart
+++ b/lib/flashy_tab_bar.dart
@@ -59,16 +59,17 @@ class FlashyTabBar extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: items.map((item) {
               var index = items.indexOf(item);
-              return GestureDetector(
-                onTap: () => onItemSelected(index),
-                child: _FlashTabBarItem(
-                  item: item,
-                  tabBarHeight: this.height,
-                  iconSize: iconSize,
-                  isSelected: index == selectedIndex,
-                  backgroundColor: bg,
-                  animationDuration: animationDuration,
-                  animationCurve: animationCurve,
+              return Expanded(child: GestureDetector(
+                  onTap: () => onItemSelected(index),
+                  child: _FlashTabBarItem(
+                    item: item,
+                    tabBarHeight: this.height,
+                    iconSize: iconSize,
+                    isSelected: index == selectedIndex,
+                    backgroundColor: bg,
+                    animationDuration: animationDuration,
+                    animationCurve: animationCurve,
+                  ),
                 ),
               );
             }).toList(),

--- a/lib/flashy_tab_bar.dart
+++ b/lib/flashy_tab_bar.dart
@@ -10,6 +10,7 @@ class FlashyTabBar extends StatelessWidget {
   final bool showElevation;
   final Duration animationDuration;
   final Curve animationCurve;
+  final List<BoxShadow> shadows;
 
   final List<FlashyTabBarItem> items;
   final ValueChanged<int> onItemSelected;
@@ -23,6 +24,12 @@ class FlashyTabBar extends StatelessWidget {
     this.backgroundColor,
     this.animationDuration = const Duration(milliseconds: 170),
     this.animationCurve = Curves.linear,
+    this.shadows = const [
+      const BoxShadow(
+        color: Colors.black12,
+        blurRadius: 3,
+      ),
+    ],
     @required this.items,
     @required this.onItemSelected,
   }) {
@@ -42,12 +49,7 @@ class FlashyTabBar extends StatelessWidget {
       decoration: BoxDecoration(
         color: bg,
         boxShadow: showElevation
-            ? [
-                const BoxShadow(
-                  color: Colors.black12,
-                  blurRadius: 3,
-                ),
-              ]
+            ? shadows
             : [],
       ),
       child: SafeArea(
@@ -59,7 +61,8 @@ class FlashyTabBar extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: items.map((item) {
               var index = items.indexOf(item);
-              return Expanded(child: GestureDetector(
+              return Expanded(
+                child: GestureDetector(
                   onTap: () => onItemSelected(index),
                   child: _FlashTabBarItem(
                     item: item,


### PR DESCRIPTION
This change helps the tab buttons take up equal space when one text is longer than the other and so forth.